### PR TITLE
docs(release): prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2026-03-10
 - **Fix**: Correct the documentation coverage workflow to run `Tools/check_docs.py` and align mutation-testing commit lint with the primary PR validation policy
 - **Fix**: Resolve Ghostwriter renderer review findings, avoid the `ShrinkTree.findMinimalParallel` Swift 6.2.4 release-build optimizer crash, and restore root-package CI compatibility with Xcode `xcodebuild` by lowering the umbrella manifest tools version to `6.0`
 - **Feat**: Add automated release tagging from `main` using conventional-commit semver bumping and rebuild documentation automatically on `main` and published releases

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import PackageDescription
 let package = Package(
     name: "MyProject",
     dependencies: [
-        .package(url: "https://github.com/your-org/InvariantSwift", from: "1.0.1")
+        .package(url: "https://github.com/brunogama/InvariantSwift", from: "0.2.0")
     ],
     targets: [
         .testTarget(


### PR DESCRIPTION
## Summary

- Promotes \`[Unreleased]\` CHANGELOG section to \`[0.2.0] - 2026-03-10\`
- Updates README installation example from \`1.0.1\` to \`0.2.0\` with the correct repository URL

## Release notes — v0.2.0

### Highlights
- Cross-platform crash isolation (\`IsolationStrategy\`, \`PosixSpawnIsolation\`, \`ThreadIsolation\`) with \`CrashReport\` and \`IsolationCapability\`
- Automated release tagging from \`main\` using conventional-commit semver bumping
- MacroTemplateKit-backed rendering for macros and Ghostwriter
- Swift 6.2.4 / Xcode CI stabilisation across concurrency, strict warnings, and xcodebuild

### Breaking changes

None.

### Upgrade

\`\`\`swift
.package(url: "https://github.com/brunogama/InvariantSwift", from: "0.2.0")
\`\`\`

## Test plan
- [ ] PR CI passes
- [ ] Merge to \`main\`
- [ ] \`v0.2.0\` tag resolves via SPM